### PR TITLE
Refactor input, limit deletion to certain prefixes, misc uplifts and fixes

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: phpdockerio/github-actions-delete-abandoned-branches:v1
+          tags: phpdockerio/github-actions-delete-abandoned-branches:v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,10 +16,19 @@ jobs:
       - name: Build action container
         run: docker build -t action_container .
 
-      - name: Run our action
+      - name: Run our action with basic options
         run: |
           docker run --rm action_container \
             --ignore-branches=deletable-but-ignored \
+            --last-commit-age-days=9 \
+            --dry-run=yes \
+            --github-token="${{ github.token }}"
+
+      - name: Run our action with more options
+        run: |
+          docker run --rm action_container \
+            --allowed-prefixes=deletable-but-ignored,another-prefix \
+            --ignore-branches=foo,bar
             --last-commit-age-days=9 \
             --dry-run=yes \
             --github-token="${{ github.token }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,16 +11,16 @@ jobs:
     name: Runs the action with no ignore branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Build action container
+        run: docker build -t action_container .
 
       - name: Run our action
-        uses: ./
-        id: delete_stuff
-        with:
-          github_token: ${{ github.token }}
-          last_commit_age_days: 9
-          dry_run: yes
-          ignore_branches: deletable-but-ignored
+        run: |
+          docker run --rm action_container \
+            --ignore-branches=deletable-but-ignored \
+            --last-commit-age-days=9 \
+            --dry-run=yes \
+            --github-token="${{ github.token }}"
 
-      - name: Get output
-        run: "echo 'Deleted branches: ${{ steps.delete_stuff.outputs.deleted_branches }}'"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,4 +23,3 @@ jobs:
             --last-commit-age-days=9 \
             --dry-run=yes \
             --github-token="${{ github.token }}"
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Build action container
         run: docker build -t action_container .
 
-      - name: Run our action with default options
+      - name: "Test: default options"
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
@@ -25,19 +25,19 @@ jobs:
             action_container \
             --github-token="${{ github.token }}"
 
-      - name: Set for deletion all branches except for deletable-but-ignored
+      - name: "Test: ignore branch 'test_prefix/two'"
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
             -e GITHUB_OUTPUT \
             -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
             action_container \
-            --ignore-branches=deletable-but-ignored \
+            --ignore-branches="test_prefix/two" \
             --last-commit-age-days=9 \
             --dry-run=yes \
             --github-token="${{ github.token }}"
 
-      - name: Set for deletion all branches named `test_prefix/*` except for `test_prefix/two`
+      - name: "Test: allow only`test_prefix/*` except for `test_prefix/two`"
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,11 +16,21 @@ jobs:
       - name: Build action container
         run: docker build -t action_container .
 
+      - name: Run our action with default options
+        run: |
+          docker run --rm -t \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_OUTPUT \
+            -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
+            action_container \
+            --github-token="${{ github.token }}"
+
       - name: Run our action with basic options
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
             -e GITHUB_OUTPUT \
+            -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
             action_container \
             --ignore-branches=deletable-but-ignored \
             --last-commit-age-days=9 \
@@ -32,6 +42,7 @@ jobs:
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
             -e GITHUB_OUTPUT \
+            -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
             action_container \
             --allowed-prefixes=deletable-but-ignored,another-prefix \
             --ignore-branches=foo,bar

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,10 @@ jobs:
 
       - name: Run our action with basic options
         run: |
-          docker run --rm action_container \
+          docker run --rm -t \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_OUTPUT \
+            action_container \
             --ignore-branches=deletable-but-ignored \
             --last-commit-age-days=9 \
             --dry-run=yes \
@@ -26,7 +29,10 @@ jobs:
 
       - name: Run our action with more options
         run: |
-          docker run --rm action_container \
+          docker run --rm -t \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_OUTPUT \
+            action_container \
             --allowed-prefixes=deletable-but-ignored,another-prefix \
             --ignore-branches=foo,bar
             --last-commit-age-days=9 \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
             -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
             action_container \
             --allowed-prefixes=deletable-but-ignored,another-prefix \
-            --ignore-branches=foo,bar
+            --ignore-branches=foo,bar \
             --last-commit-age-days=9 \
             --dry-run=yes \
             --github-token="${{ github.token }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
             action_container \
             --github-token="${{ github.token }}"
 
-      - name: Run our action with basic options
+      - name: Set for deletion all branches except for deletable-but-ignored
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
@@ -37,15 +37,15 @@ jobs:
             --dry-run=yes \
             --github-token="${{ github.token }}"
 
-      - name: Run our action with more options
+      - name: Set for deletion all branches named `test_prefix/*` except for `test_prefix/two`
         run: |
           docker run --rm -t \
             -e GITHUB_REPOSITORY \
             -e GITHUB_OUTPUT \
             -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
             action_container \
-            --allowed-prefixes=deletable-but-ignored,another-prefix \
-            --ignore-branches=foo,bar \
+            --allowed-prefixes=test_prefix/ \
+            --ignore-branches=test_prefix/two \
             --last-commit-age-days=9 \
             --dry-run=yes \
             --github-token="${{ github.token }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.11-alpine
 
 WORKDIR /application
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ A branch must meet all the following criteria to be deemed abandoned and safe to
 
 `* mandatory`
 
-| Name                   | Description                                                                                                                                     | Example                               |
-|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `last_commit_age_days` | How old in days must be the last commit into the branch for the branch to be deleted. Default: `60`                                             | `90`                                  |
-| `ignore_branches`      | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here. Default: `null`                | `foo,bar`                             |
-| `allowed_prefixes`     | Comma-separated list of prefixes a branch must match to be deleted. Default: `null`                                                             | `feature/,bugfix/`                    |
-| `dry_run`*             | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive). Default: `yes`                                    | `no`                                  |
-| `github_token`*        | The github token to use on requests to the github api. You can use the one github actions provide. Default: `null`                              | `${{ github.token }}`                 |
-| `github_base_url`      | The github API's base url. You only need to override this when using Github Enterprise on a different domain. Default: `https://api.github.com` | `https://github.mycompany.com/api/v3` |
+| Name                   | Description                                                                                                                                         | Example                               |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `github_token`*        | **Required.** The github token to use on requests to the github api. You can use the one github actions provide.                                    | `${{ github.token }}`                 |
+| `last_commit_age_days` | How old in days must be the last commit into the branch for the branch to be deleted. **Default:** `60`                                             | `90`                                  |
+| `ignore_branches`      | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here. **Default:** `null`                | `foo,bar`                             |
+| `allowed_prefixes`     | Comma-separated list of prefixes a branch must match to be deleted. **Default:** `null`                                                             | `feature/,bugfix/`                    |
+| `dry_run`              | Whether we're actually deleting branches at all. **Possible values:** `yes, no` (case sensitive). **Default:** `yes`                                | `no`                                  |
+| `github_base_url`      | The github API's base url. You only need to override this when using Github Enterprise on a different domain. **Default:** `https://api.github.com` | `https://github.mycompany.com/api/v3` |
 
 ### Note: dry run
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
     name: Satisfy my repo CDO
     steps:
       - name: Delete those pesky dead branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v2
         id: delete_stuff
         with:
           github_token: ${{ github.token }}
@@ -96,7 +96,7 @@ jobs:
     name: Satisfy my repo CDO
     steps:
       - name: Delete those pesky dead branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v2
         id: delete_stuff
         with:
           github_token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A branch must meet all the following criteria to be deemed abandoned and safe to
 | ------------- | ------------- | ------------- |
 | `ignore_branches`  | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here.  | `foo,bar`
 | `last_commit_age_days` | How old in days must be the last commit into the branch for the branch to be deleted. Default: `60` | `90`
+| `prefixes` | Comma-separated list of prefixes a branch must match to be deleted. Default: `null` | `feature/,bugfix/`
 | `dry_run`* | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive). Default: `yes` | `no`
 | `github_token`* | The github token to use on requests to the github api. You can use the one github actions provide | `${{ github.token }}`
 | `github_base_url` | The github API's base url. You only need to override this when using Github Enterprise on a different domain. Default: `https://api.github.com` | `https://github.mycompany.com/api/v3`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A branch must meet all the following criteria to be deemed abandoned and safe to
 * Must NOT be the base of an open pull request of another branch. The base of a pull request is the branch you told
   GitHub you want to merge your pull request into.
 * Must NOT be in an optional list of branches to ignore
+* Must match one of the given branch prefixes (optional)
 * Must be older than a given amount of days
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ A branch must meet all the following criteria to be deemed abandoned and safe to
 
 `* mandatory`
 
-| Name                   | Default                  | Description                                                                                                     | Example                               |
-|------------------------|:-------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `last_commit_age_days` | `60`                     | How old in days must be the last commit into the branch for the branch to be deleted                            | `90`                                  |
-| `ignore_branches`      | `null`                   | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here | `foo,bar`                             |
-| `allowed_prefixes`     | `null`                   | Comma-separated list of prefixes a branch must match to be deleted.                                             | `feature/,bugfix/`                    |
-| `dry_run`*             | `yes`                    | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive).                   | `no`                                  |
-| `github_token`*        | `null`                   | The github token to use on requests to the github api. You can use the one github actions provide               | `${{ github.token }}`                 |
-| `github_base_url`      | `https://api.github.com` | The github API's base url. You only need to override this when using Github Enterprise on a different domain    | `https://github.mycompany.com/api/v3` |
+| Name                   | Description                                                                                                                                     | Example                               |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `last_commit_age_days` | How old in days must be the last commit into the branch for the branch to be deleted. Default: `60`                                             | `90`                                  |
+| `ignore_branches`      | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here. Default: `null`                | `foo,bar`                             |
+| `allowed_prefixes`     | Comma-separated list of prefixes a branch must match to be deleted. Default: `null`                                                             | `feature/,bugfix/`                    |
+| `dry_run`*             | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive). Default: `yes`                                    | `no`                                  |
+| `github_token`*        | The github token to use on requests to the github api. You can use the one github actions provide. Default: `null`                              | `${{ github.token }}`                 |
+| `github_base_url`      | The github API's base url. You only need to override this when using Github Enterprise on a different domain. Default: `https://api.github.com` | `https://github.mycompany.com/api/v3` |
 
 ### Note: dry run
 
@@ -77,7 +77,7 @@ jobs:
 ```
 
 The following workflow will run on a schedule (daily at 13:00) and will delete all abandoned branches older than 7 days
-that are prefixed with `feature/` and `deleteme/`, leaving all the rest. 
+that are prefixed with `feature/` and `deleteme/`, leaving all the rest.
 
 ```yaml
 name: Delete abandoned branches

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ A branch must meet all the following criteria to be deemed abandoned and safe to
 
 `* mandatory`
 
-| Name  | Description | Example |
-| ------------- | ------------- | ------------- |
-| `ignore_branches`  | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here.  | `foo,bar`
-| `last_commit_age_days` | How old in days must be the last commit into the branch for the branch to be deleted. Default: `60` | `90`
-| `prefixes` | Comma-separated list of prefixes a branch must match to be deleted. Default: `null` | `feature/,bugfix/`
-| `dry_run`* | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive). Default: `yes` | `no`
-| `github_token`* | The github token to use on requests to the github api. You can use the one github actions provide | `${{ github.token }}`
-| `github_base_url` | The github API's base url. You only need to override this when using Github Enterprise on a different domain. Default: `https://api.github.com` | `https://github.mycompany.com/api/v3`
+| Name                   | Default                  | Description                                                                                                     | Example                               |
+|------------------------|:-------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `last_commit_age_days` | `60`                     | How old in days must be the last commit into the branch for the branch to be deleted                            | `90`                                  |
+| `ignore_branches`      | `null`                   | Comma-separated list of branches to ignore and never delete. You don't need to add your protected branches here | `foo,bar`                             |
+| `allowed_prefixes`     | `null`                   | Comma-separated list of prefixes a branch must match to be deleted.                                             | `feature/,bugfix/`                    |
+| `dry_run`*             | `yes`                    | Whether we're actually deleting branches at all. Possible values: `yes, no` (case sensitive).                   | `no`                                  |
+| `github_token`*        | `null`                   | The github token to use on requests to the github api. You can use the one github actions provide               | `${{ github.token }}`                 |
+| `github_base_url`      | `https://api.github.com` | The github API's base url. You only need to override this when using Github Enterprise on a different domain    | `https://github.mycompany.com/api/v3` |
 
 ### Note: dry run
 
@@ -42,7 +42,7 @@ correctly before setting `dry_run` to `no`
 ## Example
 
 The following workflow will run on a schedule (daily at 00:00) and will delete all abandoned branches older than 100
-days:
+days on a github enterprise install.
 
 ```yaml
 name: Delete abandoned branches
@@ -74,5 +74,39 @@ jobs:
 
       - name: Get output
         run: "echo 'Deleted branches: ${{ steps.delete_stuff.outputs.deleted_branches }}'"
+```
 
+The following workflow will run on a schedule (daily at 13:00) and will delete all abandoned branches older than 7 days
+that are prefixed with `feature/` and `deleteme/`, leaving all the rest. 
+
+```yaml
+name: Delete abandoned branches
+
+on:
+  # Run daily at midnight
+  schedule:
+    - cron: "0 13 * * *"
+
+  # Allow workflow to be manually run from the GitHub UI
+  workflow_dispatch:
+
+jobs:
+  cleanup_old_branches:
+    runs-on: ubuntu-latest
+    name: Satisfy my repo CDO
+    steps:
+      - name: Delete those pesky dead branches
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        id: delete_stuff
+        with:
+          github_token: ${{ github.token }}
+          last_commit_age_days: 7
+          allowed_prefixes: feature/,deleteme/
+          ignore_branches: next-version,dont-deleteme
+
+          # Disable dry run and actually get stuff deleted
+          dry_run: no
+
+      - name: Get output
+        run: "echo 'Deleted branches: ${{ steps.delete_stuff.outputs.deleted_branches }}'"
 ```

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://phpdockerio/github-actions-delete-abandoned-branches:v1'
+  image: 'docker://phpdockerio/github-actions-delete-abandoned-branches:v2'
   args:
     - --ignore-branches="${{ inputs.ignore_branches }}"
     - --last-commit-age-days="${{ inputs.last_commit_age_days }}"

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "How old in days must be the last commit into the branch for the branch to be deleted."
     required: false
     default: "60"
+  prefixes:
+    description: "Comma-separated list of prefixes a branch must match to be deleted."
+    required: false
+    default: ""
   dry_run:
     description: "Whether we're actually deleting branches at all. Defaults to 'yes'. Possible values: yes, no (case sensitive)"
     required: true
@@ -37,6 +41,7 @@ runs:
   args:
     - ${{ inputs.ignore_branches }}
     - ${{ inputs.last_commit_age_days }}
+    - ${{ inputs.prefixes }}
     - ${{ inputs.dry_run }}
     - ${{ inputs.github_token }}
     - ${{ inputs.github_base_url }}

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,9 @@ runs:
   using: 'docker'
   image: 'docker://phpdockerio/github-actions-delete-abandoned-branches:v1'
   args:
-    - ${{ inputs.ignore_branches }}
-    - ${{ inputs.last_commit_age_days }}
-    - ${{ inputs.prefixes }}
-    - ${{ inputs.dry_run }}
-    - ${{ inputs.github_token }}
-    - ${{ inputs.github_base_url }}
+    - --ignore-branches="${{ inputs.ignore_branches }}"
+    - --last-commit-age-days="${{ inputs.last_commit_age_days }}"
+    - --allowed-prefixes=${{ inputs.allowed_prefixes }}
+    - --dry-run="${{ inputs.dry_run }}"
+    - --github-token="${{ inputs.github_token }}"
+    - --github-base-url="${{ inputs.github_base_url }}"

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "How old in days must be the last commit into the branch for the branch to be deleted."
     required: false
     default: "60"
-  prefixes:
+  allowed_prefixes:
     description: "Comma-separated list of prefixes a branch must match to be deleted."
     required: false
     default: ""

--- a/main.py
+++ b/main.py
@@ -1,16 +1,7 @@
 from src import actions, io
+from src.io import InputParser
 
 if __name__ == '__main__':
-    options = io.parse_input()
-
-    deleted_branches = actions.run_action(
-        ignore_branches=ignore_branches,
-        last_commit_age_days=last_commit_age_days,
-        prefixes=prefixes,
-        dry_run=dry_run,
-        github_repo=github_repo,
-        github_token=github_token,
-        github_base_url=github_base_url
-    )
-
+    options = InputParser().parse_input()
+    deleted_branches = actions.run_action(options)
     io.format_output({'deleted_branches': deleted_branches})

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from src import actions, io
 
 if __name__ == '__main__':
-    ignore_branches, last_commit_age_days, prefixes, dry_run, github_token, github_repo, github_base_url = io.parse_input()
+    options = io.parse_input()
 
     deleted_branches = actions.run_action(
         ignore_branches=ignore_branches,

--- a/main.py
+++ b/main.py
@@ -1,11 +1,12 @@
 from src import actions, io
 
 if __name__ == '__main__':
-    ignore_branches, last_commit_age_days, dry_run, github_token, github_repo, github_base_url = io.parse_input()
+    ignore_branches, last_commit_age_days, prefixes, dry_run, github_token, github_repo, github_base_url = io.parse_input()
 
     deleted_branches = actions.run_action(
         ignore_branches=ignore_branches,
         last_commit_age_days=last_commit_age_days,
+        prefixes=prefixes,
         dry_run=dry_run,
         github_repo=github_repo,
         github_token=github_token,

--- a/src/actions.py
+++ b/src/actions.py
@@ -1,32 +1,20 @@
 from src.github import Github
+from src.io import Options
 
 
-def run_action(
-        github_repo: str,
-        ignore_branches: list,
-        last_commit_age_days: int,
-        prefixes: list,
-        github_token: str,
-        github_base_url: str,
-        dry_run: bool = True
-) -> list:
-    input_data = {
-        'github_repo': github_repo,
-        'ignore_branches': ignore_branches,
-        'last_commit_age_days': last_commit_age_days,
-        'prefixes': prefixes,
-        'dry_run': dry_run,
-        'github_base_url': github_base_url
-    }
+def run_action(options: Options) -> list:
+    print(f"Starting github action to cleanup old branches. Input: {options}")
 
-    print(f"Starting github action to cleanup old branches. Input: {input_data}")
+    github = Github(repo=options.github_repo, token=options.github_token, base_url=options.github_base_url)
 
-    github = Github(github_repo=github_repo, github_token=github_token, github_base_url=github_base_url)
-
-    branches = github.get_deletable_branches(last_commit_age_days=last_commit_age_days, ignore_branches=ignore_branches, prefixes=prefixes)
+    branches = github.get_deletable_branches(
+        last_commit_age_days=options.last_commit_age_days,
+        ignore_branches=options.ignore_branches,
+        allowed_prefixes=options.allowed_prefixes
+    )
 
     print(f"Branches queued for deletion: {branches}")
-    if dry_run is False:
+    if options.dry_run is False:
         print('This is NOT a dry run, deleting branches')
         github.delete_branches(branches=branches)
     else:

--- a/src/actions.py
+++ b/src/actions.py
@@ -5,6 +5,7 @@ def run_action(
         github_repo: str,
         ignore_branches: list,
         last_commit_age_days: int,
+        prefixes: list,
         github_token: str,
         github_base_url: str,
         dry_run: bool = True
@@ -13,6 +14,7 @@ def run_action(
         'github_repo': github_repo,
         'ignore_branches': ignore_branches,
         'last_commit_age_days': last_commit_age_days,
+        'prefixes': prefixes,
         'dry_run': dry_run,
         'github_base_url': github_base_url
     }
@@ -21,7 +23,7 @@ def run_action(
 
     github = Github(github_repo=github_repo, github_token=github_token, github_base_url=github_base_url)
 
-    branches = github.get_deletable_branches(last_commit_age_days=last_commit_age_days, ignore_branches=ignore_branches)
+    branches = github.get_deletable_branches(last_commit_age_days=last_commit_age_days, ignore_branches=ignore_branches, prefixes=prefixes)
 
     print(f"Branches queued for deletion: {branches}")
     if dry_run is False:

--- a/src/github.py
+++ b/src/github.py
@@ -17,7 +17,7 @@ class Github:
     def get_paginated_branches_url(self, page: int = 0) -> str:
         return f'{self.github_base_url}/repos/{self.github_repo}/branches?protected=false&per_page=30&page={page}'
 
-    def get_deletable_branches(self, last_commit_age_days: int, ignore_branches: list) -> list:
+    def get_deletable_branches(self, last_commit_age_days: int, ignore_branches: list, prefixes: list) -> list:
         # Default branch might not be protected
         default_branch = self.get_default_branch()
 
@@ -42,7 +42,7 @@ class Github:
 
                 print(f'Analyzing branch `{branch_name}`...')
 
-                # Immediately discard protected branches, default branch and ignored branches
+                # Immediately discard protected branches, default branch, ignored branches and branches not matching prefix
                 if branch_name == default_branch:
                     print(f'Ignoring `{branch_name}` because it is the default branch')
                     continue
@@ -56,6 +56,16 @@ class Github:
                 if branch_name in ignore_branches:
                     print(f'Ignoring `{branch_name}` because it is on the list of ignored branches')
                     continue
+
+                # If prefixes are provided, only consider branches that match one of the prefixes
+                if len(prefixes) > 0:
+                    found_prefix = False
+                    for prefix in prefixes:
+                        if branch_name.startswith(prefix):
+                            found_prefix = True
+                    if found_prefix is False:
+                        print(f'Ignoring `{branch_name}` because it does not match any provided prefix')
+                        continue
 
                 # Move on if commit is in an open pull request
                 if self.has_open_pulls(commit_hash=commit_hash):

--- a/src/io.py
+++ b/src/io.py
@@ -3,14 +3,54 @@ from os import getenv
 from typing import List
 
 
-def parse_input() -> (list, int, list, bool, str, str, str):
+class Options:
+    def __init__(
+            self,
+            ignore_branches: list[str],
+            last_commit_age_days: int,
+            allowed_prefixes: list[str],
+            dry_run: bool,
+            github_token: str,
+            github_repo: str,
+            github_base_url: str = 'https://api.github.com'
+    ):
+        self.ignore_branches = ignore_branches
+        self.last_commit_age_days = last_commit_age_days
+        self.allowed_prefixes = allowed_prefixes
+        self.dry_run = dry_run
+        self.github_token = github_token
+        self.github_repo = github_repo
+        self.github_base_url = github_base_url
+
+    def validate(self):
+        errors = []
+        if self.dry_run is None:
+            errors.append("dry_run is undefined")
+
+        if self.github_token is None:
+            errors.append("github_token is undefined")
+
+        if self.github_repo is None:
+            errors.append("github_repo is undefined")
+
+        if self.github_base_url is None:
+            errors.append("github_base_url is undefined")
+
+        if self.last_commit_age_days is None:
+            errors.append("last_commit_age_days is undefined")
+
+        if len(errors) > 0:
+            raise RuntimeError(f"Errors found while parsing input options: {errors}")
+
+
+def parse_input() -> Options:
     args: List[str] = sys.argv
 
     num_args = len(args)
 
     if num_args < 4 or num_args > 7:
         input_string = ' '.join(args)
-        expected_string = f'{args[0]} ignore_branches last_commit_age_days prefixes dry_run_yes_no github_token github_repo github_base_url'
+        expected_string = f'{args[0]} ignore_branches last_commit_age_days allowed_prefixes dry_run_yes_no github_token github_repo github_base_url'
         raise RuntimeError(f'Incorrect input: {input_string}. Expected: {expected_string}')
 
     branches_raw: str = args[1]
@@ -21,9 +61,9 @@ def parse_input() -> (list, int, list, bool, str, str, str):
     last_commit_age_days = int(args[2])
 
     prefixes_raw: str = args[3]
-    prefixes = prefixes_raw.split(',')
-    if prefixes == ['']:
-        prefixes = []
+    allowed_prefixes = prefixes_raw.split(',')
+    if allowed_prefixes == ['']:
+        allowed_prefixes = []
 
     # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
     dry_run = False if args[4] == 'no' else True
@@ -34,7 +74,19 @@ def parse_input() -> (list, int, list, bool, str, str, str):
 
     github_base_url = args[6] if num_args >= 7 else 'https://api.github.com'
 
-    return ignore_branches, last_commit_age_days, prefixes, dry_run, github_token, github_repo, github_base_url
+    options = Options(
+        ignore_branches=ignore_branches,
+        last_commit_age_days=last_commit_age_days,
+        allowed_prefixes=allowed_prefixes,
+        dry_run=dry_run,
+        github_token=github_token,
+        github_repo=github_repo,
+        github_base_url=github_base_url
+    )
+
+    options.validate()
+
+    return options
 
 
 def format_output(output_strings: dict) -> None:

--- a/src/io.py
+++ b/src/io.py
@@ -86,7 +86,7 @@ class InputParser:
             ignore_branches = []
 
         allowed_prefixes_raw: str = "" if args.allowed_prefixes is None else args.allowed_prefixes
-        allowed_prefixes = args.allowed_prefixes_raw.split(',')
+        allowed_prefixes = allowed_prefixes_raw.split(',')
         if allowed_prefixes == ['']:
             allowed_prefixes = []
 

--- a/src/io.py
+++ b/src/io.py
@@ -69,7 +69,7 @@ class InputParser:
         )
 
         parser.add_argument(
-            "--dry_run",
+            "--dry-run",
             choices=["yes", "no"],
             default="yes",
             help="Whether to delete branches at all. Defaults to 'yes'. Possible values: yes, no (case sensitive)"

--- a/src/io.py
+++ b/src/io.py
@@ -3,14 +3,14 @@ from os import getenv
 from typing import List
 
 
-def parse_input() -> (list, int, bool, str, str, str):
+def parse_input() -> (list, int, list, bool, str, str, str):
     args: List[str] = sys.argv
 
     num_args = len(args)
 
-    if num_args < 4 or num_args > 6:
+    if num_args < 4 or num_args > 7:
         input_string = ' '.join(args)
-        expected_string = f'{args[0]} ignore_branches last_commit_age_days dry_run_yes_no github_token github_repo github_base_url'
+        expected_string = f'{args[0]} ignore_branches last_commit_age_days prefixes dry_run_yes_no github_token github_repo github_base_url'
         raise RuntimeError(f'Incorrect input: {input_string}. Expected: {expected_string}')
 
     branches_raw: str = args[1]
@@ -20,16 +20,21 @@ def parse_input() -> (list, int, bool, str, str, str):
 
     last_commit_age_days = int(args[2])
 
-    # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
-    dry_run = False if args[3] == 'no' else True
+    prefixes_raw: str = args[3]
+    prefixes = prefixes_raw.split(',')
+    if prefixes == ['']:
+        prefixes = []
 
-    github_token = args[4]
+    # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
+    dry_run = False if args[4] == 'no' else True
+
+    github_token = args[5]
 
     github_repo = getenv('GITHUB_REPOSITORY')
 
-    github_base_url = args[5] if num_args >= 6 else 'https://api.github.com'
+    github_base_url = args[6] if num_args >= 7 else 'https://api.github.com'
 
-    return ignore_branches, last_commit_age_days, dry_run, github_token, github_repo, github_base_url
+    return ignore_branches, last_commit_age_days, prefixes, dry_run, github_token, github_repo, github_base_url
 
 
 def format_output(output_strings: dict) -> None:

--- a/src/io.py
+++ b/src/io.py
@@ -85,7 +85,8 @@ class InputParser:
         if ignore_branches == ['']:
             ignore_branches = []
 
-        allowed_prefixes = args.allowed_prefixes.split(',')
+        allowed_prefixes_raw: str = "" if args.allowed_prefixes is None else args.allowed_prefixes
+        allowed_prefixes = args.allowed_prefixes_raw.split(',')
         if allowed_prefixes == ['']:
             allowed_prefixes = []
 

--- a/src/io.py
+++ b/src/io.py
@@ -1,6 +1,9 @@
+import argparse
 import sys
 from os import getenv
 from typing import List
+
+DEFAULT_GITHUB_API_URL = 'https://api.github.com'
 
 
 class Options:
@@ -9,24 +12,21 @@ class Options:
             ignore_branches: list[str],
             last_commit_age_days: int,
             allowed_prefixes: list[str],
-            dry_run: bool,
             github_token: str,
             github_repo: str,
-            github_base_url: str = 'https://api.github.com'
+            dry_run: bool = True,
+            github_base_url: str = DEFAULT_GITHUB_API_URL
     ):
         self.ignore_branches = ignore_branches
         self.last_commit_age_days = last_commit_age_days
         self.allowed_prefixes = allowed_prefixes
-        self.dry_run = dry_run
         self.github_token = github_token
         self.github_repo = github_repo
+        self.dry_run = dry_run
         self.github_base_url = github_base_url
 
     def validate(self):
         errors = []
-        if self.dry_run is None:
-            errors.append("dry_run is undefined")
-
         if self.github_token is None:
             errors.append("github_token is undefined")
 
@@ -43,51 +43,67 @@ class Options:
             raise RuntimeError(f"Errors found while parsing input options: {errors}")
 
 
-def parse_input() -> Options:
-    args: List[str] = sys.argv
+class InputParser:
+    @staticmethod
+    def get_args() -> argparse.Namespace:
+        parser = argparse.ArgumentParser('Github Actions Delete Old Branches')
 
-    num_args = len(args)
+        parser.add_argument("--ignore_branches", help="Comma-separated list of branches to ignore")
 
-    if num_args < 4 or num_args > 7:
-        input_string = ' '.join(args)
-        expected_string = f'{args[0]} ignore_branches last_commit_age_days allowed_prefixes dry_run_yes_no github_token github_repo github_base_url'
-        raise RuntimeError(f'Incorrect input: {input_string}. Expected: {expected_string}')
+        parser.add_argument("--allowed_prefixes",
+                            help="Comma-separated list of prefixes a branch must match to be deleted")
+        parser.add_argument("--github_token")
 
-    branches_raw: str = args[1]
-    ignore_branches = branches_raw.split(',')
-    if ignore_branches == ['']:
-        ignore_branches = []
+        parser.add_argument(
+            "--github_base_url",
+            default=DEFAULT_GITHUB_API_URL,
+            help="The API base url to be used in requests to GitHub Enterprise"
+        )
 
-    last_commit_age_days = int(args[2])
+        parser.add_argument(
+            "--last_commit_age_days",
+            help="How old in days must be the last commit into the branch for the branch to be deleted",
+            type=int,
+            required=True,
+        )
 
-    prefixes_raw: str = args[3]
-    allowed_prefixes = prefixes_raw.split(',')
-    if allowed_prefixes == ['']:
-        allowed_prefixes = []
+        parser.add_argument(
+            "--dry_run",
+            choices=["yes", "no"],
+            default="yes",
+            help="Whether to delete branches at all. Defaults to 'yes'. Possible values: yes, no (case sensitive)"
+        )
 
-    # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
-    dry_run = False if args[4] == 'no' else True
+        return parser.parse_args()
 
-    github_token = args[5]
+    def parse_input(self) -> Options:
+        args = self.get_args()
 
-    github_repo = getenv('GITHUB_REPOSITORY')
+        branches_raw: str = args.ignore_branches
+        ignore_branches = branches_raw.split(',')
+        if ignore_branches == ['']:
+            ignore_branches = []
 
-    github_base_url = args[6] if num_args >= 7 else 'https://api.github.com'
+        allowed_prefixes = args.allowed_prefixes.split(',')
+        if allowed_prefixes == ['']:
+            allowed_prefixes = []
 
-    options = Options(
-        ignore_branches=ignore_branches,
-        last_commit_age_days=last_commit_age_days,
-        allowed_prefixes=allowed_prefixes,
-        dry_run=dry_run,
-        github_token=github_token,
-        github_repo=github_repo,
-        github_base_url=github_base_url
-    )
+        # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
+        dry_run = False if args.dry_run == 'no' else True
 
-    options.validate()
+        options = Options(
+            ignore_branches=ignore_branches,
+            last_commit_age_days=args.last_commit_age_days,
+            allowed_prefixes=allowed_prefixes,
+            dry_run=dry_run,
+            github_token=args.github_token,
+            github_repo=getenv('GITHUB_REPOSITORY'),
+            github_base_url=args.github_base_url
+        )
 
-    return options
+        options.validate()
 
+        return options
 
 def format_output(output_strings: dict) -> None:
     file_path = getenv('GITHUB_OUTPUT')

--- a/src/io.py
+++ b/src/io.py
@@ -49,7 +49,6 @@ class InputParser:
             help="How old in days must be the last commit into the branch for the branch to be deleted",
             default=60,
             type=int,
-            required=True,
         )
 
         parser.add_argument(

--- a/src/io.py
+++ b/src/io.py
@@ -1,7 +1,5 @@
 import argparse
-import sys
 from os import getenv
-from typing import List
 
 DEFAULT_GITHUB_API_URL = 'https://api.github.com'
 
@@ -48,20 +46,23 @@ class InputParser:
     def get_args() -> argparse.Namespace:
         parser = argparse.ArgumentParser('Github Actions Delete Old Branches')
 
-        parser.add_argument("--ignore_branches", help="Comma-separated list of branches to ignore")
-
-        parser.add_argument("--allowed_prefixes",
-                            help="Comma-separated list of prefixes a branch must match to be deleted")
-        parser.add_argument("--github_token")
+        parser.add_argument("--ignore-branches", help="Comma-separated list of branches to ignore")
 
         parser.add_argument(
-            "--github_base_url",
+            "--allowed-prefixes",
+            help="Comma-separated list of prefixes a branch must match to be deleted"
+        )
+
+        parser.add_argument("--github-token", required=True)
+
+        parser.add_argument(
+            "--github-base-url",
             default=DEFAULT_GITHUB_API_URL,
             help="The API base url to be used in requests to GitHub Enterprise"
         )
 
         parser.add_argument(
-            "--last_commit_age_days",
+            "--last-commit-age-days",
             help="How old in days must be the last commit into the branch for the branch to be deleted",
             type=int,
             required=True,
@@ -104,6 +105,7 @@ class InputParser:
         options.validate()
 
         return options
+
 
 def format_output(output_strings: dict) -> None:
     file_path = getenv('GITHUB_OUTPUT')

--- a/src/io.py
+++ b/src/io.py
@@ -23,23 +23,6 @@ class Options:
         self.dry_run = dry_run
         self.github_base_url = github_base_url
 
-    def validate(self):
-        errors = []
-        if self.github_token is None:
-            errors.append("github_token is undefined")
-
-        if self.github_repo is None:
-            errors.append("github_repo is undefined")
-
-        if self.github_base_url is None:
-            errors.append("github_base_url is undefined")
-
-        if self.last_commit_age_days is None:
-            errors.append("last_commit_age_days is undefined")
-
-        if len(errors) > 0:
-            raise RuntimeError(f"Errors found while parsing input options: {errors}")
-
 
 class InputParser:
     @staticmethod
@@ -64,6 +47,7 @@ class InputParser:
         parser.add_argument(
             "--last-commit-age-days",
             help="How old in days must be the last commit into the branch for the branch to be deleted",
+            default=60,
             type=int,
             required=True,
         )
@@ -93,7 +77,7 @@ class InputParser:
         # Dry run can only be either `true` or `false`, as strings due to github actions input limitations
         dry_run = False if args.dry_run == 'no' else True
 
-        options = Options(
+        return Options(
             ignore_branches=ignore_branches,
             last_commit_age_days=args.last_commit_age_days,
             allowed_prefixes=allowed_prefixes,
@@ -102,10 +86,6 @@ class InputParser:
             github_repo=getenv('GITHUB_REPOSITORY'),
             github_base_url=args.github_base_url
         )
-
-        options.validate()
-
-        return options
 
 
 def format_output(output_strings: dict) -> None:

--- a/src/io.py
+++ b/src/io.py
@@ -63,7 +63,7 @@ class InputParser:
     def parse_input(self) -> Options:
         args = self.get_args()
 
-        branches_raw: str = args.ignore_branches
+        branches_raw: str = "" if args.ignore_branches is None else args.ignore_branches
         ignore_branches = branches_raw.split(',')
         if ignore_branches == ['']:
             ignore_branches = []


### PR DESCRIPTION
The action now takes a whole bunch of inputs that it didn't originally, creating unwieldy input management and functions with tons of arguments. This PR refactors input to make it more manageable.

It also brings in the ability to limit deletion to branches with a certain prefix via https://github.com/phpdocker-io/github-actions-delete-abandoned-branches/pull/21

**Changes:**
 * Refactor input management to populate a self validating object
 * Add the option to limit deletion to branches with a certain prefix (https://github.com/phpdocker-io/github-actions-delete-abandoned-branches/pull/21)
 * Refactor github actions outputs - closes https://github.com/phpdocker-io/github-actions-delete-abandoned-branches/issues/23
 * Tweak tests to run directly against the container having the current code
 * Pin container usage to v2
 * Upgrade to python 3.11
 * Update README