### PR TITLE
Ensure v1 only runs v1 container

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: phpdockerio/github-actions-delete-abandoned-branches:latest
+          tags: phpdockerio/github-actions-delete-abandoned-branches:v1

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://phpdockerio/github-actions-delete-abandoned-branches:latest'
+  image: 'docker://phpdockerio/github-actions-delete-abandoned-branches:v1'
   args:
     - ${{ inputs.ignore_branches }}
     - ${{ inputs.last_commit_age_days }}


### PR DESCRIPTION
About to publish v2 with different container args, so better ensure we aren't running against mismatched containers